### PR TITLE
Corrige a concatenação dos arquivos para S.O. Mac/Linux

### DIFF
--- a/utils/file-utils.js
+++ b/utils/file-utils.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const path = require('path');
 
 module.exports = {
 
@@ -6,7 +7,7 @@ module.exports = {
         const files = fs.readdirSync(directoryPath);
         const filesReturn = [];
         files.forEach((file) => {
-            filesReturn.push(directoryPath.concat("\\").concat(file));
+            filesReturn.push(path.join(directoryPath, file));
         });
         return filesReturn;
     },


### PR DESCRIPTION
Em sistemas operacionais com Mac/Linux a barra é diferente do Windows, dessa forma não pode deixar fixa.